### PR TITLE
Add `server::send_trusted_domain_list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added a public API that provides `frame` functionality to avoid exposing `oinq`'s
   `frame`. This change improves the modularity of the `review-protocol`.
+- `server::send_trusted_domain_list` to facilitate sending the trusted domain
+  list from the server to the client.
 
 ## [0.2.0] - 2024-04-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.2.0"
 edition = "2021"
 
 [features]
-client = ["oinq", "quinn", "bincode"]
-server = ["oinq", "quinn"]
+client = ["bincode", "oinq", "quinn"]
+server = ["bincode", "oinq", "quinn"]
 
 [dependencies]
 anyhow = "1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,18 +1,99 @@
 //! Client-specific protocol implementation.
 
+#[cfg(feature = "client")]
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
+#[cfg(any(feature = "client", feature = "server"))]
+use num_enum::{FromPrimitive, IntoPrimitive};
+#[cfg(feature = "client")]
 use oinq::frame::{self, RecvError, SendError};
+#[cfg(feature = "client")]
 pub use oinq::message::{send_err, send_ok, send_request};
+#[cfg(feature = "client")]
 use quinn::{Connection, RecvStream, SendStream};
 
+#[cfg(feature = "client")]
 use crate::{AgentInfo, HandshakeError};
+
+/// Numeric representation of the message types.
+#[cfg(any(feature = "client", feature = "server"))]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, IntoPrimitive, PartialEq)]
+#[repr(u32)]
+pub(crate) enum RequestCode {
+    /// Start DNS filtering
+    DnsStart = 1,
+
+    /// Stop DNS filtering
+    DnsStop = 2,
+
+    /// Reboot the host
+    Reboot = 4,
+
+    /// Reload the configuration
+    ReloadConfig = 6,
+
+    /// Fetch the TI database and reload it
+    ReloadTi = 5,
+
+    /// Collect resource usage stats
+    ResourceUsage = 7,
+
+    /// Update the list of tor exit nodes
+    TorExitNodeList = 8,
+
+    /// Update the list of sampling policies
+    SamplingPolicyList = 9,
+
+    /// Update traffic filter rules
+    ReloadFilterRule = 10,
+
+    /// Get configuration
+    GetConfig = 11,
+
+    /// Set Configuration
+    SetConfig = 12,
+
+    /// Delete the list of sampling policies
+    DeleteSamplingPolicy = 13,
+
+    /// Update the list of Internal network
+    InternalNetworkList = 14,
+
+    /// Update the list of allow
+    AllowList = 15,
+
+    /// Update the list of block
+    BlockList = 16,
+
+    /// Request Echo (for ping)
+    EchoRequest = 17,
+
+    /// Update the list of trusted User-agent
+    TrustedUserAgentList = 18,
+
+    /// Update the list of trusted domains
+    TrustedDomainList = 0,
+
+    /// Collect process list
+    ProcessList = 19,
+
+    /// Update the semi-supervised models
+    SemiSupervisedModels = 20,
+
+    /// Shutdown the host
+    Shutdown = 21,
+
+    /// Unknown request
+    #[num_enum(default)]
+    Unknown = u32::MAX,
+}
 
 /// Sends a handshake request and processes the response.
 ///
 /// # Errors
 ///
 /// Returns `HandshakeError` if the handshake failed.
+#[cfg(feature = "client")]
 pub async fn handshake(
     conn: &Connection,
     app_name: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "client")]
 pub mod client;
 #[cfg(feature = "client")]
 pub mod frame;
@@ -10,8 +9,10 @@ pub mod server;
 mod test;
 pub mod types;
 
-use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
+
+use serde::{Deserialize, Serialize};
+#[cfg(any(feature = "client", feature = "server"))]
 use thiserror::Error;
 
 /// The error type for a handshake failure.

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,83 +1,15 @@
 //! Request handling for the agent.
 
 use async_trait::async_trait;
-use num_enum::{FromPrimitive, IntoPrimitive};
+use num_enum::FromPrimitive;
 pub use oinq::request::{parse_args, send_response};
 use thiserror::Error;
 
-use crate::types::{Config, HostNetworkGroup, Process, ResourceUsage, TrafficFilterRule};
+use crate::{
+    client::RequestCode,
+    types::{Config, HostNetworkGroup, Process, ResourceUsage, TrafficFilterRule},
+};
 
-/// Numeric representation of the message types.
-#[derive(Clone, Copy, Debug, Eq, FromPrimitive, IntoPrimitive, PartialEq)]
-#[repr(u32)]
-enum RequestCode {
-    /// Start DNS filtering
-    DnsStart = 1,
-
-    /// Stop DNS filtering
-    DnsStop = 2,
-
-    /// Reboot the host
-    Reboot = 4,
-
-    /// Reload the configuration
-    ReloadConfig = 6,
-
-    /// Fetch the TI database and reload it
-    ReloadTi = 5,
-
-    /// Collect resource usage stats
-    ResourceUsage = 7,
-
-    /// Update the list of tor exit nodes
-    TorExitNodeList = 8,
-
-    /// Update the list of sampling policies
-    SamplingPolicyList = 9,
-
-    /// Update traffic filter rules
-    ReloadFilterRule = 10,
-
-    /// Get configuration
-    GetConfig = 11,
-
-    /// Set Configuration
-    SetConfig = 12,
-
-    /// Delete the list of sampling policies
-    DeleteSamplingPolicy = 13,
-
-    /// Update the list of Internal network
-    InternalNetworkList = 14,
-
-    /// Update the list of allow
-    AllowList = 15,
-
-    /// Update the list of block
-    BlockList = 16,
-
-    /// Request Echo (for ping)
-    EchoRequest = 17,
-
-    /// Update the list of trusted User-agent
-    TrustedUserAgentList = 18,
-
-    /// Update the list of trusted domains
-    TrustedDomainList = 0,
-
-    /// Collect process list
-    ProcessList = 19,
-
-    /// Update the semi-supervised models
-    SemiSupervisedModels = 20,
-
-    /// Shutdown the host
-    Shutdown = 21,
-
-    /// Unknown request
-    #[num_enum(default)]
-    Unknown = u32::MAX,
-}
 /// The error type for handling a request.
 #[derive(Debug, Error)]
 pub enum HandlerError {

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,7 +9,7 @@ use oinq::{
 use quinn::Connection;
 use semver::{Version, VersionReq};
 
-use crate::{AgentInfo, HandshakeError};
+use crate::{client::RequestCode, AgentInfo, HandshakeError};
 
 /// Processes a handshake message and sends a response.
 ///
@@ -70,4 +70,29 @@ pub async fn handshake(
             version_req.to_string(),
         ))
     }
+}
+
+/// Sends a list of trusted domains to the client.
+///
+/// # Errors
+///
+/// Returns an error if serialization failed or communication with the client failed.
+pub async fn send_trusted_domain_list(conn: &Connection, list: &[String]) -> anyhow::Result<()> {
+    use anyhow::anyhow;
+    use bincode::Options;
+
+    let Ok(mut msg) = bincode::serialize::<u32>(&RequestCode::TrustedDomainList.into()) else {
+        unreachable!("serialization of u32 into memory buffer should not fail")
+    };
+    let ser = bincode::DefaultOptions::new();
+    msg.extend(ser.serialize(list)?);
+
+    let (mut send, mut recv) = conn.open_bi().await?;
+    frame::send_raw(&mut send, &msg).await?;
+
+    let mut response = vec![];
+    frame::recv_raw(&mut recv, &mut response).await?;
+    frame::recv::<Result<(), String>>(&mut recv, &mut response)
+        .await?
+        .map_err(|e| anyhow!(e))
 }


### PR DESCRIPTION
This allows the server to send a list of trusted domains to the client without relying on lower-level protocols to do so.