### PR TITLE
Update oinq error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `server::send_trusted_domain_list` to facilitate sending the trusted domain
   list from the server to the client.
 
+## Changed
+
+- `HandshakeError::ReadError` now provides the underlying error as
+  `std::io::Error`, which is more informative than the previous custom error
+  type.
+
 ## [0.2.0] - 2024-04-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1"
 bincode = { version = "1", optional = true }
 ipnet = { version = "2", features = ["serde"] }
 num_enum = "0.7"
-oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.12.0", optional = true }
+oinq = { git = "https://github.com/petabi/oinq.git", rev = "29ad689d", optional = true }
 quinn = { version = "0.10", optional = true }
 semver = "1"
 serde = { version = "1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ pub enum HandshakeError {
     ConnectionClosed,
     #[error("connection lost")]
     ConnectionLost(#[from] quinn::ConnectionError),
-    #[error("cannot receive a message")]
-    ReadError(#[from] quinn::ReadError),
+    #[error("cannot receive a message: {0}")]
+    ReadError(#[from] std::io::Error),
     #[error("cannot send a message")]
     WriteError(#[from] quinn::WriteError),
     #[error("arguments are too long")]


### PR DESCRIPTION
The receive functions in oinq now returns `std::io::Result`.