### PR TITLE
Support `oinq` 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `HandshakeError::ReadError` now provides the underlying error as
   `std::io::Error`, which is more informative than the previous custom error
   type.
+- Update `oinq` to version `0.13.0`. Updating to this version results in the
+  following changes.
+  - Bump dependencies.
+    - Update quinn to version 0.11.
+    - Update rustls to version 0.23.
+    - Update rcgen to version 0.13.
+  - Fixed the handling of the error types provided by `oinq`. `oinq` has
+    changed from providing the `RecvError`/`SendError` error type to providing
+    the `std::io::Error` error type. As a result, `review-protocol` has also
+    been modified to `std::io::Error` or convert to the correct internally
+    defined error type.
 
 ## [0.2.0] - 2024-04-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,18 @@ async-trait = "0.1"
 bincode = { version = "1", optional = true }
 ipnet = { version = "2", features = ["serde"] }
 num_enum = "0.7"
-oinq = { git = "https://github.com/petabi/oinq.git", rev = "29ad689d", optional = true }
-quinn = { version = "0.10", optional = true }
+oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.13.0", optional = true }
+quinn = { version = "0.11", optional = true }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 
 [dev-dependencies]
 lazy_static = "1"
-quinn = "0.10"
-rcgen = "0.12"
-rustls = "0.21"
+quinn = { version = "0.11", features = ["ring"] }
+rcgen = "0.13"
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "std",
+] }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,19 +22,20 @@ lazy_static! {
 /// Creates a bidirectional channel, returning server's send and receive and
 /// client's send and receive streams.
 pub(crate) async fn channel() -> Channel {
-    use std::net::{IpAddr, Ipv6Addr, SocketAddr};
-
+    use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
+    use std::{
+        net::{IpAddr, Ipv6Addr, SocketAddr},
+        sync::Arc,
+    };
     const TEST_SERVER_NAME: &str = "test-server";
     const TEST_PORT: u16 = 60190;
 
     let cert =
         rcgen::generate_simple_self_signed([TEST_SERVER_NAME.to_string()]).expect("infallible");
-    let cert_chain = vec![rustls::Certificate(
-        cert.serialize_der().expect("infallible"),
-    )];
-    let key_der = rustls::PrivateKey(cert.serialize_private_key_der());
-    let server_config =
-        quinn::ServerConfig::with_single_cert(cert_chain, key_der).expect("infallible");
+    let cert_der = vec![CertificateDer::from(cert.cert)];
+    let key_der = PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+    let server_config = quinn::ServerConfig::with_single_cert(cert_der.clone(), key_der.into())
+        .expect("infallible");
     let server_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), TEST_PORT);
 
     let server_endpoint = {
@@ -53,30 +54,35 @@ pub(crate) async fn channel() -> Channel {
         }
     };
 
+    let handle = tokio::spawn(async move {
+        let server_connection = match server_endpoint.accept().await {
+            Some(conn) => match conn.await {
+                Ok(conn) => conn,
+                Err(e) => panic!("{}", e.to_string()),
+            },
+            None => panic!("connection closed"),
+        };
+        let (server_send, mut server_recv) = server_connection.accept_bi().await.unwrap();
+        let mut server_buf = [0; 5];
+        server_recv.read_exact(&mut server_buf).await.unwrap();
+        (server_connection, server_send, server_recv)
+    });
+
     let mut root_cert_store = rustls::RootCertStore::empty();
-    root_cert_store.add_parsable_certificates(&[cert.serialize_der().expect("infallible")]);
+    root_cert_store.add_parsable_certificates(cert_der);
+    let client_config = quinn::ClientConfig::with_root_certificates(Arc::new(root_cert_store))
+        .expect("invalid client config");
     let client_endpoint =
         quinn::Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)).unwrap();
-    let client_config = quinn::ClientConfig::with_root_certificates(root_cert_store);
     let client_connecting = client_endpoint
         .connect_with(client_config, server_addr, TEST_SERVER_NAME)
         .unwrap();
 
     let client_connection = client_connecting.await.unwrap();
-
     let (mut client_send, client_recv) = client_connection.open_bi().await.unwrap();
     client_send.write_all(b"ready").await.unwrap();
 
-    let server_connection = match server_endpoint.accept().await {
-        Some(conn) => match conn.await {
-            Ok(conn) => conn,
-            Err(e) => panic!("{}", e.to_string()),
-        },
-        None => panic!("connection closed"),
-    };
-    let (server_send, mut server_recv) = server_connection.accept_bi().await.unwrap();
-    let mut server_buf = [0; 5];
-    server_recv.read_exact(&mut server_buf).await.unwrap();
+    let (server_connection, server_send, server_recv) = handle.await.unwrap();
 
     Channel {
         server: self::Endpoint {


### PR DESCRIPTION
- Update `quinn`/`rustls`/`rcgen` version.
- Modify the associated code based on the crate's versioning of dependencies.
- Fixed to correctly handle error types provided by `oinq`.

Close: #4