### PR TITLE
Simplify `handshake` function return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The `handshake` function in the `client` module no longer returns the
+  `SendStream` and `RecvStream` handles. These values were previously returned
+  but not used by the caller, so they have been removed to simplify the
+  function's return type.
+
 ## [0.3.0] - 2024-05-28
 
 ### Added
@@ -87,6 +96,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `client::handshake` implements the application-level handshake process for the
   client after a QUIC connection is established.
 
+[Unreleased]: https://github.com/petabi/review-protocol/compare/0.3.0...main
 [0.3.0]: https://github.com/petabi/review-protocol/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/petabi/review-protocol/compare/0.1.2...0.2.0
 [0.1.2]: https://github.com/petabi/review-protocol/compare/0.1.1...0.1.2

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,7 @@ use oinq::frame::{self};
 #[cfg(feature = "client")]
 pub use oinq::message::{send_err, send_ok, send_request};
 #[cfg(feature = "client")]
-use quinn::{Connection, RecvStream, SendStream};
+use quinn::Connection;
 
 #[cfg(feature = "client")]
 use crate::{AgentInfo, HandshakeError};
@@ -99,7 +99,7 @@ pub async fn handshake(
     app_name: &str,
     app_version: &str,
     protocol_version: &str,
-) -> Result<(SendStream, RecvStream), HandshakeError> {
+) -> Result<(), HandshakeError> {
     // A placeholder for the address of this agent. Will be replaced by the
     // server.
     //
@@ -127,7 +127,7 @@ pub async fn handshake(
         .map_err(handle_handshake_send_io_error)?;
 
     match frame::recv::<Result<&str, &str>>(&mut recv, &mut buf).await {
-        Ok(Ok(_)) => Ok((send, recv)),
+        Ok(Ok(_)) => Ok(()),
         Ok(Err(e)) => Err(HandshakeError::IncompatibleProtocol(
             protocol_version.to_string(),
             e.to_string(),


### PR DESCRIPTION
Since every request opens a new stream, the stream used for the handshake is not needed.