### PR TITLE
Remove central server's fields; Remove `ReconvergeConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   but not used by the caller, so they have been removed to simplify the
   function's return type.
 
+### Removed
+
+- Removed `ReconvergeConfig`.
+- Removed `review_address` field from `HogConfig`, `PigletConfig`, `CrusherConfig`
+
 ## [0.3.0] - 2024-05-28
 
 ### Added

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,13 +40,11 @@ pub struct Process {
 pub enum Config {
     Hog(HogConfig),
     Piglet(PigletConfig),
-    Reconverge(ReconvergeConfig),
     Crusher(CrusherConfig),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HogConfig {
-    pub review_address: SocketAddr,
     pub giganto_address: Option<SocketAddr>,
     pub active_protocols: Option<Vec<String>>,
     pub active_sources: Option<Vec<String>>,
@@ -54,21 +52,13 @@ pub struct HogConfig {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PigletConfig {
-    pub review_address: SocketAddr,
     pub giganto_address: Option<SocketAddr>,
     pub log_options: Option<Vec<String>>,
     pub http_file_types: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct ReconvergeConfig {
-    pub review_address: SocketAddr,
-    pub giganto_address: Option<SocketAddr>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
 pub struct CrusherConfig {
-    pub review_address: SocketAddr,
     pub giganto_ingest_address: Option<SocketAddr>,
     pub giganto_publish_address: Option<SocketAddr>,
 }


### PR DESCRIPTION
I have removed all fields from `ReconvergeConfig`, leaving it as an empty struct.
However, I have commented it out instead of deleting it to allow for the addition of configuration fields in the future.

Closes #11 