### PR TITLE
Add client::connect to streamline connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `client::connect` function that combines `quinn::Endpoint::connect` and
+  `review-protocol::client::handshake`. This simplifies the connection process
+  for applications using review-protocol, reducing code duplication.
+  Applications using review-protocol should now use `client::connect` instead of
+  calling `Endpoint::connect` and `client::handshake` separately.
+
 ### Changed
 
 - The `handshake` function in the `client` module no longer returns the


### PR DESCRIPTION
This change introduces `client::connect` function that combines `quinn::Endpoint::connect` and `review-protocol::client::handshake`. It allows users to establish a connection and perform the review-protocol handshake in a single function call.