### PR TITLE
Moved EventCategory definition from review-database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   for applications using review-protocol, reducing code duplication.
   Applications using review-protocol should now use `client::connect` instead of
   calling `Endpoint::connect` and `client::handshake` separately.
+- Moved `EventCategory` definition from review-database.
 
 ### Changed
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -72,3 +72,17 @@ pub struct HostNetworkGroup {
 
 // IP address, port numbers, and protocols.
 pub type TrafficFilterRule = (IpNet, Option<Vec<u16>>, Option<Vec<u16>>);
+
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+pub enum EventCategory {
+    Unknown = 0,
+    Reconnaissance = 1,
+    InitialAccess,
+    Execution,
+    CredentialAccess,
+    Discovery,
+    LateralMovement,
+    CommandAndControl,
+    Exfiltration,
+    Impact,
+}


### PR DESCRIPTION
Close #15 

- Moved `EventCategory` definition from review-database
- Removed `HttpThreat` category