### PR TITLE
Encapsulate quinn::Endpoint and improve client API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - New `Endpoint` struct in the `client` module that wraps `quinn::Endpoint`.
   This provides a protocol-specific endpoint for outbound connections, improving
   encapsulation and making the API more idiomatic to review-protocol.
-- `client::connect` function that combines `quinn::Endpoint::connect` and
+- `Endpoint::connect` function that combines `quinn::Endpoint::connect` and
   `review-protocol::client::handshake`. This simplifies the connection process
   for applications using review-protocol, reducing code duplication.
   Applications using review-protocol should now create an `Endpoint` instance
-  and call `client::connect` instead of calling `quinn::Endpoint::connect` and
+  and call `Endpoint::connect` instead of calling `quinn::Endpoint::connect` and
   `client::handshake` separately.
 - Introduced `EventCategory` enum to categorize security events.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- New `Endpoint` struct in the `client` module that wraps `quinn::Endpoint`.
+  This provides a protocol-specific endpoint for outbound connections, improving
+  encapsulation and making the API more idiomatic to review-protocol.
 - `client::connect` function that combines `quinn::Endpoint::connect` and
   `review-protocol::client::handshake`. This simplifies the connection process
   for applications using review-protocol, reducing code duplication.
-  Applications using review-protocol should now use `client::connect` instead of
-  calling `Endpoint::connect` and `client::handshake` separately.
+  Applications using review-protocol should now create an `Endpoint` instance
+  and call `client::connect` instead of calling `quinn::Endpoint::connect` and
+  `client::handshake` separately.
 - Introduced `EventCategory` enum to categorize security events.
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ ipnet = { version = "2", features = ["serde"] }
 num_enum = "0.7"
 oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.13.0", optional = true }
 quinn = { version = "0.11", optional = true }
+rustls = { version = "0.23", default-features = false }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -88,9 +88,6 @@ pub(crate) enum RequestCode {
     Unknown = u32::MAX,
 }
 
-#[cfg(feature = "client")]
-pub enum ConnectionError {}
-
 /// Connects to the server and performs a handshake.
 ///
 /// # Errors

--- a/src/client.rs
+++ b/src/client.rs
@@ -132,87 +132,87 @@ impl Endpoint {
         inner.set_default_client_config(config);
         Ok(Self { inner })
     }
-}
 
-/// Connects to the server and performs a handshake.
-///
-/// # Errors
-///
-/// Returns an error if the connection fails or the server requires a different
-/// protocol version.
-#[cfg(feature = "client")]
-pub async fn connect(
-    endpoint: &Endpoint,
-    server_addr: SocketAddr,
-    server_name: &str,
-    app_name: &str,
-    app_version: &str,
-    protocol_version: &str,
-) -> std::io::Result<Connection> {
-    use std::io;
+    /// Connects to the server and performs a handshake.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection fails or the server requires a different
+    /// protocol version.
+    #[cfg(feature = "client")]
+    pub async fn connect(
+        &self,
+        server_addr: SocketAddr,
+        server_name: &str,
+        app_name: &str,
+        app_version: &str,
+        protocol_version: &str,
+    ) -> std::io::Result<Connection> {
+        use std::io;
 
-    let connecting = endpoint
-        .inner
-        .connect(server_addr, server_name)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-    let conn = connecting.await.map_err(|e| {
-        // quinn (as of 0.11) provides automatic conversion from
-        // `ConnectionError` to `ReadError`, and from `ReadError` to
-        // `io::Error`. However, the conversion treats all `ConnectionError`
-        // variants as `NotConnected`, which is too generic. We need to provide
-        // more specific error messages.
-        use quinn::ConnectionError;
-        match e {
-            ConnectionError::ApplicationClosed(e) => {
-                std::io::Error::new(io::ErrorKind::ConnectionAborted, e.to_string())
+        let connecting = self
+            .inner
+            .connect(server_addr, server_name)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let conn = connecting.await.map_err(|e| {
+            // quinn (as of 0.11) provides automatic conversion from
+            // `ConnectionError` to `ReadError`, and from `ReadError` to
+            // `io::Error`. However, the conversion treats all `ConnectionError`
+            // variants as `NotConnected`, which is too generic. We need to provide
+            // more specific error messages.
+            use quinn::ConnectionError;
+            match e {
+                ConnectionError::ApplicationClosed(e) => {
+                    std::io::Error::new(io::ErrorKind::ConnectionAborted, e.to_string())
+                }
+                ConnectionError::CidsExhausted => {
+                    io::Error::new(io::ErrorKind::Other, "connection IDs exhausted")
+                }
+                ConnectionError::ConnectionClosed(e) => {
+                    std::io::Error::new(io::ErrorKind::ConnectionAborted, e.to_string())
+                }
+                ConnectionError::LocallyClosed => {
+                    io::Error::new(io::ErrorKind::NotConnected, "locally closed")
+                }
+                ConnectionError::Reset => io::Error::from(io::ErrorKind::ConnectionReset),
+                ConnectionError::TimedOut => io::Error::from(io::ErrorKind::TimedOut),
+                ConnectionError::TransportError(e) => {
+                    std::io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+                }
+                ConnectionError::VersionMismatch => {
+                    io::Error::new(io::ErrorKind::ConnectionRefused, "version mismatch")
+                }
             }
-            ConnectionError::CidsExhausted => {
-                io::Error::new(io::ErrorKind::Other, "connection IDs exhausted")
-            }
-            ConnectionError::ConnectionClosed(e) => {
-                std::io::Error::new(io::ErrorKind::ConnectionAborted, e.to_string())
-            }
-            ConnectionError::LocallyClosed => {
-                io::Error::new(io::ErrorKind::NotConnected, "locally closed")
-            }
-            ConnectionError::Reset => io::Error::from(io::ErrorKind::ConnectionReset),
-            ConnectionError::TimedOut => io::Error::from(io::ErrorKind::TimedOut),
-            ConnectionError::TransportError(e) => {
-                std::io::Error::new(io::ErrorKind::InvalidData, e.to_string())
-            }
-            ConnectionError::VersionMismatch => {
-                io::Error::new(io::ErrorKind::ConnectionRefused, "version mismatch")
-            }
+        })?;
+
+        // A placeholder for the address of this agent. Will be replaced by the
+        // server.
+        //
+        // TODO: This is unnecessary in handshake, and thus should be removed in the
+        // future.
+        let addr = if conn.remote_address().is_ipv6() {
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+        } else {
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+        };
+
+        let agent_info = AgentInfo {
+            app_name: app_name.to_string(),
+            version: app_version.to_string(),
+            protocol_version: protocol_version.to_string(),
+            addr,
+        };
+
+        let (mut send, mut recv) = conn.open_bi().await?;
+        let mut buf = Vec::new();
+        frame::send(&mut send, &mut buf, &agent_info).await?;
+        match frame::recv::<Result<&str, &str>>(&mut recv, &mut buf).await? {
+            Ok(_) => Ok(conn),
+            Err(e) => Err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                format!("server requires protocol version {e}"),
+            )),
         }
-    })?;
-
-    // A placeholder for the address of this agent. Will be replaced by the
-    // server.
-    //
-    // TODO: This is unnecessary in handshake, and thus should be removed in the
-    // future.
-    let addr = if conn.remote_address().is_ipv6() {
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
-    } else {
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
-    };
-
-    let agent_info = AgentInfo {
-        app_name: app_name.to_string(),
-        version: app_version.to_string(),
-        protocol_version: protocol_version.to_string(),
-        addr,
-    };
-
-    let (mut send, mut recv) = conn.open_bi().await?;
-    let mut buf = Vec::new();
-    frame::send(&mut send, &mut buf, &agent_info).await?;
-    match frame::recv::<Result<&str, &str>>(&mut recv, &mut buf).await? {
-        Ok(_) => Ok(conn),
-        Err(e) => Err(io::Error::new(
-            io::ErrorKind::ConnectionRefused,
-            format!("server requires protocol version {e}"),
-        )),
     }
 }
 


### PR DESCRIPTION
- Introduce new `Endpoint` struct in client module to wrap `quinn::Endpoint`
- Update `connect` function to use the new `Endpoint` type
- Add `new` method to `Endpoint` for creating outbound connections
- Update CHANGELOG to reflect new API changes and usage instructions
- Add rustls as a dependency for TLS configuration
