### PR TITLE
Refactor Endpoint creation and hide rustls dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,23 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- New `Endpoint` struct in the `client` module that wraps `quinn::Endpoint`.
-  This provides a protocol-specific endpoint for outbound connections, improving
+- New `EndpointBuilder` struct in the `client` module for creating customized
+  endpoints. This allows for more flexible configuration of TLS settings and
+  root certificates.
+  - `EndpointBuilder::new` function to create a new builder with a given
+    address, certificate, and key.
+  - `EndpointBuilder::add_root_certs` method to add root certificates to the
+    endpoint's certificate store.
+  - `EndpointBuilder::build` method to construct the final `Endpoint` instance.
+- `Endpoint` struct in the `client` module that wraps `quinn::Endpoint`. This
+  provides a protocol-specific endpoint for outbound connections, improving
   encapsulation and making the API more idiomatic to review-protocol.
-- `Endpoint::connect` function that combines `quinn::Endpoint::connect` and
-  `review-protocol::client::handshake`. This simplifies the connection process
-  for applications using review-protocol, reducing code duplication.
-  Applications using review-protocol should now create an `Endpoint` instance
-  and call `Endpoint::connect` instead of calling `quinn::Endpoint::connect` and
-  `client::handshake` separately.
+  - `Endpoint::connect` function that combines `quinn::Endpoint::connect` and
+    `review-protocol::client::handshake`. This simplifies the connection process
+    for applications using review-protocol, reducing code duplication.
+    Applications using review-protocol should now create an `Endpoint` instance
+    using `EndpointBuilder` and call `Endpoint::connect` instead of calling
+    `quinn::Endpoint::connect` and `client::handshake` separately.
 - Introduced `EventCategory` enum to categorize security events.
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ num_enum = "0.7"
 oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.13.0", optional = true }
 quinn = { version = "0.11", optional = true }
 rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"


### PR DESCRIPTION
- Introduce EndpointBuilder for flexible endpoint configuration
- Remove direct rustls dependency from public API