### PR TITLE
Add client API to fetch server configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Methods like `local_addr`, `remote_addr`, `close_reason`, `open_bi`, and `accept_bi`
     to interact with the connection.
 - Introduced `EventCategory` enum to categorize security events.
+- New client API `get_config()` to fetch configuration from the server. This
+  method allows clients to request and receive configuration data from the
+  server. The format of the configuration is left to the caller to interpret.
 
 ### Changed
 


### PR DESCRIPTION
This commit introduces a new API allowing clients to retrieve configuration data from the server. The format and interpretation of this configuration are left to the caller, providing flexibility for different use cases.