### PR TITLE
Minimize dependencies with default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `SendStream` and `RecvStream` handles. These values were previously returned
   but not used by the caller, so they have been removed to simplify the
   function's return type.
+- Minimized dependencies when only default features are used.
+  - Made several dependencies optional and tied them to specific features.
+    `anyhow`, `async-trait`, `num_enum`, `semver`, and `thiserror` are now
+    optional dependencies.
+  - Modified `unary_request` function to return `std::io::Result` instead of
+    `anyhow::Result`.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,22 +4,40 @@ version = "0.3.0"
 edition = "2021"
 
 [features]
-client = ["bincode", "oinq", "quinn", "rustls", "rustls-pemfile"]
-server = ["bincode", "oinq", "quinn"]
+client = [
+    "async-trait",
+    "bincode",
+    "num_enum",
+    "oinq",
+    "quinn",
+    "rustls",
+    "rustls-pemfile",
+    "semver",
+    "thiserror",
+]
+server = [
+    "anyhow",
+    "bincode",
+    "num_enum",
+    "oinq",
+    "quinn",
+    "semver",
+    "thiserror",
+]
 
 [dependencies]
-anyhow = "1"
-async-trait = "0.1"
+anyhow = { version = "1", optional = true }
+async-trait = { version = "0.1", optional = true }
 bincode = { version = "1", optional = true }
 ipnet = { version = "2", features = ["serde"] }
-num_enum = "0.7"
+num_enum = { version = "0.7", optional = true }
 oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.13.0", optional = true }
 quinn = { version = "0.11", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
 rustls-pemfile = { version = "2", optional = true }
-semver = "1"
+semver = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"] }
-thiserror = "1"
+thiserror = { version = "1", optional = true }
 
 [dev-dependencies]
 lazy_static = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ pub mod client;
 pub mod frame;
 #[cfg(feature = "client")]
 pub mod request;
-#[cfg(feature = "server")]
 pub mod server;
 #[cfg(test)]
 mod test;
@@ -74,19 +73,15 @@ pub async fn unary_request<I, O>(
     recv: &mut quinn::RecvStream,
     code: u32,
     input: I,
-) -> anyhow::Result<O>
+) -> std::io::Result<O>
 where
     I: serde::Serialize,
     O: serde::de::DeserializeOwned,
 {
-    use anyhow::Context;
-
     let mut buf = vec![];
     oinq::message::send_request(send, &mut buf, code, input).await?;
 
-    oinq::frame::recv(recv, &mut buf)
-        .await
-        .context("invalid response")
+    oinq::frame::recv(recv, &mut buf).await
 }
 
 #[cfg(test)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,16 +1,19 @@
 //! Server-specific protocol implementation.
 
+#[cfg(feature = "server")]
 use std::net::SocketAddr;
 
-#[cfg(any(feature = "client", feature = "server"))]
+#[cfg(feature = "client")]
 use num_enum::{FromPrimitive, IntoPrimitive};
+#[cfg(feature = "server")]
 use oinq::{
     frame,
     message::{send_err, send_ok},
 };
-use quinn::Connection;
+#[cfg(feature = "server")]
 use semver::{Version, VersionReq};
 
+#[cfg(feature = "server")]
 use crate::{
     client, handle_handshake_recv_io_error, handle_handshake_send_io_error, AgentInfo,
     HandshakeError,
@@ -65,6 +68,7 @@ pub(crate) enum RequestCode {
     Unknown = u32::MAX,
 }
 
+#[cfg(feature = "server")]
 /// Processes a handshake message and sends a response.
 ///
 /// # Errors
@@ -75,7 +79,7 @@ pub(crate) enum RequestCode {
 ///
 /// * panic if it failed to parse version requirement string.
 pub async fn handshake(
-    conn: &Connection,
+    conn: &quinn::Connection,
     addr: SocketAddr,
     version_req: &str,
     highest_protocol_version: &str,
@@ -126,12 +130,16 @@ pub async fn handshake(
     }
 }
 
+#[cfg(feature = "server")]
 /// Sends a list of trusted domains to the client.
 ///
 /// # Errors
 ///
 /// Returns an error if serialization failed or communication with the client failed.
-pub async fn send_trusted_domain_list(conn: &Connection, list: &[String]) -> anyhow::Result<()> {
+pub async fn send_trusted_domain_list(
+    conn: &quinn::Connection,
+    list: &[String],
+) -> anyhow::Result<()> {
     use anyhow::anyhow;
     use bincode::Options;
 


### PR DESCRIPTION
Minimized dependencies when only default features are used.
- Made several dependencies optional and tied them to specific features.
  `anyhow`, `async-trait`, `num_enum`, `semver`, and `thiserror` are now
  optional dependencies.
- Modified `unary_request` function to return `std::io::Result` instead of
  `anyhow::Result`.