### PR TITLE
Deprecate client::handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Deprecated
+
+- The `handshake` function in the `client` module is deprecated. This function
+  will be removed in the next major/minor release. Applications using
+  review-protocol should now create a `Connection` instance using
+  `ConnectionBuilder` instead of calling `quinn::Endpoint::connect` and
+  `client::handshake` separately.
+
 ## [0.4.0] - 2024-07-22
 
 ### Added
@@ -141,6 +151,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `client::handshake` implements the application-level handshake process for the
   client after a QUIC connection is established.
 
+[Unreleased]: https://github.com/petabi/review-protocol/compare/0.4.0...main
 [0.4.0]: https://github.com/petabi/review-protocol/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/petabi/review-protocol/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/petabi/review-protocol/compare/0.1.2...0.2.0

--- a/src/client.rs
+++ b/src/client.rs
@@ -363,6 +363,10 @@ impl Connection {
 ///
 /// Returns `HandshakeError` if the handshake failed.
 #[cfg(feature = "client")]
+#[deprecated(
+    since = "0.4.1",
+    note = "Use `ConnectionBuilder::connect` instead, which provides more flexibility."
+)]
 pub async fn handshake(
     conn: &quinn::Connection,
     app_name: &str,


### PR DESCRIPTION
The `handshake` function in the `client` module is deprecated. This function will be removed in the next major/minor release. Applications using review-protocol should now create a `Connection` instance using `ConnectionBuilder` instead of calling `quinn::Endpoint::connect` and `client::handshake` separately.