### PR TITLE
Add open_uni method to Connection struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Introduced a new method `open_uni` in the `Connection` struct. This method
+  initiates an outgoing unidirectional stream and directly corresponds to the
+  `open_uni` method of the underlying `quinn::Connection`. This addition is for
+  backward-compatibility and will be removed when this crate provides all the
+  necessary features without exposing quinn's types.
+
 ## [0.4.1] - 2024-07-30
 
 ### Added
@@ -171,6 +181,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `client::handshake` implements the application-level handshake process for the
   client after a QUIC connection is established.
 
+[Unreleased]: https://github.com/petabi/review-protocol/compare/0.4.1...main
 [0.4.1]: https://github.com/petabi/review-protocol/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/petabi/review-protocol/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/petabi/review-protocol/compare/0.2.0...0.3.0

--- a/src/client.rs
+++ b/src/client.rs
@@ -376,6 +376,16 @@ impl Connection {
         self.connection.open_bi()
     }
 
+    /// Initiates an outgoing unidirectional stream.
+    ///
+    /// This directly corresponds to the `open_uni` method of the underlying
+    /// `quinn::Connection`. In the future, this method may be removed in favor
+    /// of this crate's own implementation to provide additional features.
+    #[must_use]
+    pub fn open_uni(&self) -> quinn::OpenUni {
+        self.connection.open_uni()
+    }
+
     /// Accepts an incoming bidirectional stream.
     ///
     /// This directly corresponds to the `accept_bi` method of the underlying


### PR DESCRIPTION
This commit introduces a new method `open_uni` to the `Connection` struct, which allows initiating an outgoing unidirectional stream. The method directly wraps the `open_uni` method of the underlying `quinn::Connection`.

This addition is intended for backward-compatibility purposes and may be removed in future versions when this crate provides all necessary features without exposing quinn's types directly.

Closes #31.