### PR TITLE
Add get_trusted_domain_list method to client API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Implemented `get_trusted_domain_list` method in the client API to fetch the
+  list of trusted domains from the server.
+
 ## [0.4.2] - 2024-07-31
 
 ### Added
@@ -181,6 +188,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `client::handshake` implements the application-level handshake process for the
   client after a QUIC connection is established.
 
+[Unreleased]: https://github.com/petabi/review-protocol/compare/0.4.2...main
 [0.4.2]: https://github.com/petabi/review-protocol/compare/0.4.1...0.4.2
 [0.4.1]: https://github.com/petabi/review-protocol/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/petabi/review-protocol/compare/0.3.0...0.4.0


### PR DESCRIPTION
- Implement `get_trusted_domain_list` to fetch trusted domains
- Create generic `request` function for RPC-like calls
- Refactor `get_config` to use new request function
- Move common logic to unary_request for better modularity

This commit enhances the client API by adding a new method and improving the overall structure and reusability of the codebase.