### PR TITLE
Add to the client API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Implemented `get_trusted_domain_list` method in the client API to fetch the
-  list of trusted domains from the server.
+- Implemented new client API methods:
+  - `get_allow_list`: Retrieves the list of allowed networks
+  - `get_block_list`: Retrieves the list of blocked networks
+  - `get_internal_network_list`: Retrieves the list of internal networks
+  - `get_tor_exit_node_list`: Retrieves the list of Tor exit nodes
+  - `get_trusted_domain_list`: Retrieves the list of trusted domains
+  - `get_trusted_user_agent_list`: Retrieves the list of trusted user agents
 
 ## [0.4.2] - 2024-07-31
 

--- a/src/client/api.rs
+++ b/src/client/api.rs
@@ -3,7 +3,7 @@ use std::io;
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::Connection;
-use crate::{server, unary_request};
+use crate::{server, types::HostNetworkGroup, unary_request};
 
 /// The client API.
 impl Connection {
@@ -19,6 +19,50 @@ impl Connection {
         res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 
+    /// Fetches the list of allowed networks from the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response is invalid.
+    pub async fn get_allow_list(&self) -> io::Result<HostNetworkGroup> {
+        let res: Result<HostNetworkGroup, String> =
+            request(self, server::RequestCode::GetAllowList, ()).await?;
+        res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    /// Fetches the list of blocked networks from the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response is invalid.
+    pub async fn get_block_list(&self) -> io::Result<HostNetworkGroup> {
+        let res: Result<HostNetworkGroup, String> =
+            request(self, server::RequestCode::GetBlockList, ()).await?;
+        res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    /// Fetches the list of internal networks from the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response is invalid.
+    pub async fn get_internal_network_list(&self) -> io::Result<HostNetworkGroup> {
+        let res: Result<HostNetworkGroup, String> =
+            request(self, server::RequestCode::GetInternalNetworkList, ()).await?;
+        res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    /// Fetches the list of Tor exit nodes from the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response is invalid.
+    pub async fn get_tor_exit_node_list(&self) -> io::Result<Vec<String>> {
+        let res: Result<Vec<String>, String> =
+            request(self, server::RequestCode::GetTorExitNodeList, ()).await?;
+        res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
     /// Fetches the list of trusted domains from the server.
     ///
     /// # Errors
@@ -27,6 +71,17 @@ impl Connection {
     pub async fn get_trusted_domain_list(&self) -> io::Result<Vec<String>> {
         let res: Result<Vec<String>, String> =
             request(self, server::RequestCode::GetTrustedDomainList, ()).await?;
+        res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    /// Fetches the list of trusted user agents from the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response is invalid.
+    pub async fn get_trusted_user_agent_list(&self) -> io::Result<Vec<String>> {
+        let res: Result<Vec<String>, String> =
+            request(self, server::RequestCode::GetTrustedUserAgentList, ()).await?;
         res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 }


### PR DESCRIPTION
- get_tor_exit_node_list
- get_trusted_user_agent_list
- get_internal_network_list
- get_allow_list
- get_block_list
- get_trusted_domain_list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced several new methods to improve network management and security, including:
		- `get_allow_list`: Retrieves allowed networks.
		- `get_block_list`: Retrieves blocked networks.
		- `get_internal_network_list`: Retrieves internal networks.
		- `get_tor_exit_node_list`: Retrieves Tor exit nodes.
		- `get_trusted_domain_list`: Retrieves trusted domains.
		- `get_trusted_user_agent_list`: Retrieves trusted user agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->