### PR TITLE
Remove redundant read in send_trusted_tomain_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   that invokes this method. Instead, the server should sends a message that
   invokes `Handler::update_config`.
 
+### Fixed
+
+- `send_trusted_tomain_list` no longer tries to receive a response twice,
+  causing the "unexpected end of file" error.
+
 ## [0.4.2] - 2024-07-31
 
 ### Added

--- a/src/server.rs
+++ b/src/server.rs
@@ -154,7 +154,6 @@ pub async fn send_trusted_domain_list(
     frame::send_raw(&mut send, &msg).await?;
 
     let mut response = vec![];
-    frame::recv_raw(&mut recv, &mut response).await?;
     frame::recv::<Result<(), String>>(&mut recv, &mut response)
         .await?
         .map_err(|e| anyhow!(e))


### PR DESCRIPTION
`send_trusted_tomain_list` attempted to read from the communication channel the client's response twice. The extra read caused the function to fail with an "unexpected end of file" error. This commit removes the extra read.