### PR TITLE
Fix arg parsing for Handler::trusted_domain_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the `request::Handler::trusted_domain_list` function to correctly parse
+  the argument (#39).
+
 ## [0.5.0] - 2024-09-05
 
 ### Added
@@ -207,6 +214,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `client::handshake` implements the application-level handshake process for the
   client after a QUIC connection is established.
 
+[Unreleased]: https://github.com/petabi/review-protocol/compare/0.5.0...main
 [0.5.0]: https://github.com/petabi/review-protocol/compare/0.4.2...0.5.0
 [0.4.2]: https://github.com/petabi/review-protocol/compare/0.4.1...0.4.2
 [0.4.1]: https://github.com/petabi/review-protocol/compare/0.4.0...0.4.1

--- a/src/request.rs
+++ b/src/request.rs
@@ -195,13 +195,8 @@ pub async fn handle<H: Handler>(
                     .map_err(HandlerError::SendError)?;
             }
             RequestCode::TrustedDomainList => {
-                let domains = parse_args::<Result<Vec<&str>, String>>(body)
-                    .map_err(HandlerError::RecvError)?;
-                let result = if let Ok(domains) = domains {
-                    handler.trusted_domain_list(&domains).await
-                } else {
-                    Err("invalid request".to_string())
-                };
+                let domains = parse_args::<Vec<&str>>(body).map_err(HandlerError::RecvError)?;
+                let result = handler.trusted_domain_list(&domains).await;
                 send_response(send, &mut buf, result)
                     .await
                     .map_err(HandlerError::SendError)?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -180,3 +180,131 @@ pub async fn notify_config_update(conn: &quinn::Connection) -> anyhow::Result<()
         .await?
         .map_err(|e| anyhow!(e))
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(all(feature = "client", feature = "server"))]
+    #[tokio::test]
+    async fn trusted_domain_list() {
+        use std::{
+            io,
+            net::{IpAddr, Ipv6Addr, SocketAddr},
+        };
+
+        use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
+
+        // server configuration
+        const SERVER_NAME: &str = "test-server";
+        const SERVER_PORT: u16 = 60191;
+        const SERVER_ADDR: SocketAddr =
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), SERVER_PORT);
+
+        // client configuration
+        const CLIENT_NAME: &str = "test-client";
+        const APP_NAME: &str = "review-protocol";
+        const APP_VERSION: &str = "1.0.0";
+        const PROTOCOL_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+        let server_certified_key =
+            rcgen::generate_simple_self_signed([SERVER_NAME.to_string()]).expect("infallible");
+        let server_cert_pem = server_certified_key.cert.pem();
+        let server_certs_der = vec![CertificateDer::from(server_certified_key.cert)];
+        let server_key_der =
+            PrivatePkcs8KeyDer::from(server_certified_key.key_pair.serialize_der());
+        let server_config =
+            quinn::ServerConfig::with_single_cert(server_certs_der.clone(), server_key_der.into())
+                .expect("infallible");
+
+        let server_endpoint = {
+            // The loop is only useful when multiple tests are run in parallel
+            loop {
+                break match quinn::Endpoint::server(server_config.clone(), SERVER_ADDR) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        if e.kind() == io::ErrorKind::AddrInUse {
+                            std::thread::sleep(std::time::Duration::from_millis(1000));
+                            continue;
+                        } else {
+                            panic!("{}", e);
+                        }
+                    }
+                };
+            }
+        };
+        let server_handle = tokio::spawn(async move {
+            let server_conn = match server_endpoint.accept().await {
+                Some(conn) => match conn.await {
+                    Ok(conn) => conn,
+                    Err(e) => panic!("{}", e),
+                },
+                None => panic!("no connection"),
+            };
+            let client_addr = server_conn.remote_address();
+            let agent_info = crate::server::handshake(
+                &server_conn,
+                client_addr,
+                PROTOCOL_VERSION,
+                PROTOCOL_VERSION,
+            )
+            .await
+            .unwrap();
+            (server_conn, agent_info)
+        });
+
+        let client_certified_key =
+            rcgen::generate_simple_self_signed([CLIENT_NAME.to_string()]).expect("infallible");
+        let client_cert_pem = client_certified_key.cert.pem();
+        let client_key_pem = client_certified_key.key_pair.serialize_pem();
+        let mut builder = crate::client::ConnectionBuilder::new(
+            SERVER_NAME,
+            SERVER_ADDR,
+            APP_NAME,
+            APP_VERSION,
+            PROTOCOL_VERSION,
+            client_cert_pem.as_bytes(),
+            client_key_pem.as_bytes(),
+        )
+        .unwrap();
+        let mut server_cert_pem_buf = io::Cursor::new(server_cert_pem.as_bytes());
+        builder.add_root_certs(&mut server_cert_pem_buf).unwrap();
+
+        // Connect to the server
+        let client_conn = builder.connect().await.unwrap();
+        let (server_conn, agent_info) = server_handle.await.unwrap();
+        assert_eq!(agent_info.app_name, APP_NAME);
+        assert_eq!(agent_info.version, APP_VERSION);
+
+        // Test `server::send_trusted_domain_list`
+        const TRUSTED_DOMAIN_LIST: &[&str] = &["example.com", "example.org"];
+        let domains_to_send = TRUSTED_DOMAIN_LIST
+            .iter()
+            .map(|&domain| domain.to_string())
+            .collect::<Vec<_>>();
+
+        struct Handler {}
+
+        #[async_trait::async_trait]
+        impl crate::request::Handler for Handler {
+            async fn trusted_domain_list(&mut self, domains: &[&str]) -> Result<(), String> {
+                if domains == TRUSTED_DOMAIN_LIST {
+                    Ok(())
+                } else {
+                    Err("unexpected domain list".to_string())
+                }
+            }
+        }
+
+        let mut handler = Handler {};
+        let handler_conn = client_conn.clone();
+        let client_handle = tokio::spawn(async move {
+            let (mut send, mut recv) = handler_conn.accept_bi().await.unwrap();
+
+            crate::request::handle(&mut handler, &mut send, &mut recv).await
+        });
+        let server_res =
+            crate::server::send_trusted_domain_list(&server_conn, &domains_to_send).await;
+        assert!(server_res.is_ok());
+        let client_res = client_handle.await.unwrap();
+        assert!(client_res.is_ok());
+    }
+}


### PR DESCRIPTION
`request::Handler::trusted_domain_list` parsed the arguments incorrectly, returning an invalid error message.

Fixes #39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the trusted domain list parsing, improving request handling reliability.

- **New Features**
	- Introduced a comprehensive test for the trusted domain list functionality, ensuring correct data exchange between server and client.

- **Refactor**
	- Simplified error handling for the trusted domain list request, enhancing code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->