### PR TITLE
Remove deprecated handshake function from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed
+
+- `client::handshake` was deprecated in version 0.4.1 and has been removed in
+  this version. Applications using review-protocol should now create a
+  `Connection` instance using `ConnectionBuilder` instead.
+
 ### Fixed
 
 - Fixed the `request::Handler::trusted_domain_list` function to correctly parse

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-protocol"
-version = "0.5.0"
+version = "0.6.0-alpha.1"
 edition = "2021"
 
 [features]

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ use oinq::frame::{self};
 pub use oinq::message::{send_err, send_ok, send_request};
 
 #[cfg(feature = "client")]
-use crate::{AgentInfo, HandshakeError};
+use crate::AgentInfo;
 
 /// Numeric representation of the message types that a client should handle.
 #[cfg(any(feature = "client", feature = "server"))]
@@ -405,17 +405,14 @@ impl Connection {
 /// # Errors
 ///
 /// Returns `HandshakeError` if the handshake failed.
-#[cfg(feature = "client")]
-#[deprecated(
-    since = "0.4.1",
-    note = "Use `ConnectionBuilder::connect` instead, which provides more flexibility."
-)]
-pub async fn handshake(
+#[cfg(test)]
+#[cfg(feature = "server")]
+pub(crate) async fn handshake(
     conn: &quinn::Connection,
     app_name: &str,
     app_version: &str,
     protocol_version: &str,
-) -> Result<(), HandshakeError> {
+) -> Result<(), super::HandshakeError> {
     // A placeholder for the address of this agent. Will be replaced by the
     // server.
     //
@@ -444,7 +441,7 @@ pub async fn handshake(
 
     match frame::recv::<Result<&str, &str>>(&mut recv, &mut buf).await {
         Ok(Ok(_)) => Ok(()),
-        Ok(Err(e)) => Err(HandshakeError::IncompatibleProtocol(
+        Ok(Err(e)) => Err(super::HandshakeError::IncompatibleProtocol(
             protocol_version.to_string(),
             e.to_string(),
         )),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub enum HandshakeError {
     IncompatibleProtocol(String, String),
 }
 
-#[cfg(any(feature = "client", feature = "server"))]
+#[cfg(feature = "server")]
 fn handle_handshake_send_io_error(e: std::io::Error) -> HandshakeError {
     if e.kind() == std::io::ErrorKind::InvalidData {
         HandshakeError::MessageTooLarge
@@ -43,7 +43,7 @@ fn handle_handshake_send_io_error(e: std::io::Error) -> HandshakeError {
     }
 }
 
-#[cfg(any(feature = "client", feature = "server"))]
+#[cfg(feature = "server")]
 fn handle_handshake_recv_io_error(e: std::io::Error) -> HandshakeError {
     match e.kind() {
         std::io::ErrorKind::InvalidData => HandshakeError::InvalidMessage,
@@ -88,7 +88,7 @@ where
 mod tests {
     use crate::test::{channel, TOKEN};
 
-    #[cfg(all(feature = "client", feature = "server"))]
+    #[cfg(feature = "server")]
     #[tokio::test]
     async fn handshake() {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -122,7 +122,7 @@ mod tests {
         assert!(res.is_ok());
     }
 
-    #[cfg(all(feature = "client", feature = "server"))]
+    #[cfg(feature = "server")]
     #[tokio::test]
     async fn handshake_version_incompatible_err() {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -153,7 +153,7 @@ mod tests {
         assert!(res.is_err());
     }
 
-    #[cfg(all(feature = "client", feature = "server"))]
+    #[cfg(feature = "server")]
     #[tokio::test]
     async fn handshake_incompatible_err() {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};


### PR DESCRIPTION
`client::handshake` was deprecated in version 0.4.1 and has been removed in this version. Applications using review-protocol should now create a `Connection` instance using `ConnectionBuilder` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Transitioned to using `ConnectionBuilder` for establishing connections, enhancing clarity in connection management.
	- Updated version to "0.6.0-alpha.1," indicating new features and changes in a pre-release state.

- **Bug Fixes**
	- Improved parsing for trusted domain lists, ensuring accurate handling of inputs.

- **Refactor**
	- Restricted access to the `handshake` function, enhancing encapsulation and error management.
	- Adjusted error handling to utilize a different error type for better context.

- **Documentation**
	- Updated CHANGELOG to reflect significant changes and removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->