### PR TITLE
Add server::Connection to the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `server::Connection` encapsulates the QUIC connection from a client and
+  provides a protocol-specific connection. This change improves encapsulation
+  and makes the API more idiomatic to review-protocol. Currently it provides the
+  following API:
+  - `send_trusted_domain_list`
+
 ## [0.7.0] - 2024-09-28
 
 ### Added
@@ -234,6 +244,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `client::handshake` implements the application-level handshake process for the
   client after a QUIC connection is established.
 
+[Unreleased]: https://github.com/petabi/review-protocol/compare/0.7.0...main
 [0.7.0]: https://github.com/petabi/review-protocol/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/petabi/review-protocol/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/petabi/review-protocol/compare/0.4.2...0.5.0

--- a/src/client/api.rs
+++ b/src/client/api.rs
@@ -158,7 +158,7 @@ mod tests {
             use bincode::Options;
             use num_enum::FromPrimitive;
 
-            let (mut send, mut recv) = handler_conn.connection().accept_bi().await.unwrap();
+            let (mut send, mut recv) = handler_conn.as_quinn().accept_bi().await.unwrap();
             let mut buf = Vec::with_capacity(size_of::<u32>());
             let codec = bincode::DefaultOptions::new();
             let (code, body) = oinq::message::recv_request_raw(&mut recv, &mut buf)

--- a/src/server.rs
+++ b/src/server.rs
@@ -71,14 +71,13 @@ pub(crate) enum RequestCode {
 #[cfg(all(test, feature = "server"))]
 #[derive(Clone, Debug)]
 pub(crate) struct Connection {
-    endpoint: quinn::Endpoint,
     conn: quinn::Connection,
 }
 
 #[cfg(all(test, feature = "server"))]
 impl Connection {
-    pub(crate) fn new(endpoint: quinn::Endpoint, conn: quinn::Connection) -> Self {
-        Self { endpoint, conn }
+    pub(crate) fn new(conn: quinn::Connection) -> Self {
+        Self { conn }
     }
 
     pub(crate) fn connection(&self) -> &quinn::Connection {
@@ -86,7 +85,7 @@ impl Connection {
     }
 
     pub(crate) fn close(&self) {
-        self.endpoint.close(0u32.into(), b"");
+        self.conn.close(0u32.into(), b"");
     }
 }
 

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -1,0 +1,32 @@
+use oinq::frame;
+
+use super::Connection;
+use crate::client;
+
+/// The server API.
+impl Connection {
+    /// Sends a list of trusted domains to the client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization failed or communication with the client failed.
+    pub async fn send_trusted_domain_list(&self, list: &[String]) -> anyhow::Result<()> {
+        use anyhow::anyhow;
+        use bincode::Options;
+
+        let Ok(mut msg) = bincode::serialize::<u32>(&client::RequestCode::TrustedDomainList.into())
+        else {
+            unreachable!("serialization of u32 into memory buffer should not fail")
+        };
+        let ser = bincode::DefaultOptions::new();
+        msg.extend(ser.serialize(list)?);
+
+        let (mut send, mut recv) = self.conn.open_bi().await?;
+        frame::send_raw(&mut send, &msg).await?;
+
+        let mut response = vec![];
+        frame::recv::<Result<(), String>>(&mut recv, &mut response)
+            .await?
+            .map_err(|e| anyhow!(e))
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -195,7 +195,7 @@ impl TestEnvironment {
         assert_eq!(agent_info.app_name, APP_NAME);
         assert_eq!(agent_info.version, APP_VERSION);
 
-        let server_conn = crate::server::Connection::new(server_endpoint, server_conn.clone());
+        let server_conn = crate::server::Connection::new(server_conn.clone());
         (server_conn, client_conn)
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -195,8 +195,10 @@ impl TestEnvironment {
         assert_eq!(agent_info.app_name, APP_NAME);
         assert_eq!(agent_info.version, APP_VERSION);
 
-        let server_conn = crate::server::Connection::new(server_conn.clone());
-        (server_conn, client_conn)
+        (
+            crate::server::Connection::from_quinn(server_conn),
+            client_conn,
+        )
     }
 
     pub(crate) fn teardown(&self, server_conn: crate::server::Connection) {


### PR DESCRIPTION
This struct will be used to implement the encapsulation proposed in #13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new section in the changelog for "Unreleased" changes.
  - Added several asynchronous methods to retrieve network-related data, including allow/block lists and trusted domains.
  - Implemented a new method to send a list of trusted domains to clients.

- **Bug Fixes**
  - Improved connection handling and error management in the server's connection logic.

- **Documentation**
  - Enhanced documentation for new methods and their usage.

- **Refactor**
  - Updated connection initialization methods for better encapsulation and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->