### PR TITLE
Modify the derive macro of EventCategory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `send_allowlist`
   - `send_trusted_domain_list`
 
+### Changed
+
+- Modified the derive macro of EventCategory to match the EventCategory in REview.
+  The previous derive macro `Serialize_repr, Deserialize_repr` caused
+  the deserialize operation for event to fail in REview.
+
 ## [0.7.0] - 2024-09-28
 
 ### Added

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,7 +44,7 @@ pub struct HostNetworkGroup {
 // IP address, port numbers, and protocols.
 pub type TrafficFilterRule = (IpNet, Option<Vec<u16>>, Option<Vec<u16>>);
 
-#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, PartialEq, Serialize_repr)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum EventCategory {
     Unknown = 0,


### PR DESCRIPTION
Close #49 

Modify the serialization and deserialization derive macro to match the EventCategory in Manager.
- Deserialize_repr -> Deserialize
- Serialize_repr -> Serialize

The serialized event using the EventCategory with `Serialize_repr` macro can not be deserialized by `bincode::deserialize()` function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new methods `send_allowlist` and `send_trusted_domain_list` for enhanced connection management.
  
- **Changes**
	- Updated the `EventCategory` enum to improve serialization and deserialization behavior, aligning it with the REview standard.
  
- **Documentation**
	- Updated the changelog to reflect recent changes and improvements in the API, including the introduction of the `server::Connection`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->