### PR TITLE
Add client API `get_pretrained_model`, `get_renewed_certificate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - The `client` module provides the following functions to send requests to the
   server:
   - `Connection::get_data_source`
+- Implemented new client API methods:
+  - `get_pretrained_model`: Retrieves the pretrained model.
+  - `renew_certificate`: Retrieves the renew certificate.
 
 ## [0.8.0] - 2024-10-11
 

--- a/src/client/api.rs
+++ b/src/client/api.rs
@@ -114,6 +114,28 @@ impl Connection {
             request(self, server::RequestCode::GetTrustedUserAgentList, ()).await?;
         res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
+
+    /// Fetches the pretrained model from the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response is invalid.
+    pub async fn get_pretrained_model(&self, name: &str) -> io::Result<Vec<u8>> {
+        let res: Result<Vec<u8>, String> =
+            request(self, server::RequestCode::GetPretrainedModel, name).await?;
+        res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    /// Fetches the renew certificate from the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response is invalid.
+    pub async fn renew_certificate(&self, cert: &[u8]) -> io::Result<(String, String)> {
+        let res: Result<(String, String), String> =
+            request(self, server::RequestCode::RenewCertificate, cert).await?;
+        res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
 }
 
 async fn request<I, O>(conn: &Connection, code: server::RequestCode, input: I) -> io::Result<O>


### PR DESCRIPTION
Close: #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced two new methods in the client API: 
		- `get_pretrained_model` for retrieving pretrained models.
		- `renew_certificate` for obtaining renewed certificates.
- **Documentation**
	- Updated `CHANGELOG.md` to reflect recent changes and previous version highlights, including server-side functionality updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->