### PR TITLE
Modify `get_internal_network_list` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `Connection::send_internal_network_list`
   - `Connection::send_tor_exit_node_list`
 
+### Changed
+
+- Modified `get_internal_network_list` to request a list of internal networks
+  for a target Semi-supervised Engine.
+
 ## [0.8.1] - 2024-11-15
 
 ### Added

--- a/src/client/api.rs
+++ b/src/client/api.rs
@@ -62,9 +62,9 @@ impl Connection {
     /// # Errors
     ///
     /// Returns an error if the request fails or the response is invalid.
-    pub async fn get_internal_network_list(&self) -> io::Result<HostNetworkGroup> {
+    pub async fn get_internal_network_list(&self, key: &str) -> io::Result<HostNetworkGroup> {
         let res: Result<HostNetworkGroup, String> =
-            request(self, server::RequestCode::GetInternalNetworkList, ()).await?;
+            request(self, server::RequestCode::GetInternalNetworkList, key).await?;
         res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 


### PR DESCRIPTION
This modification allows you to request internal network list from the Central Management Server for specific targets.
- Add an argument fo type String to `get_internal_network_list`.
- Modify the `request` called within `get_internal_network_list` to include a String.

Close: #57