### PR TITLE
Unify time field type of EventMessage struct to i64

### DIFF
--- a/src/client/api.rs
+++ b/src/client/api.rs
@@ -693,7 +693,10 @@ mod tests {
     async fn insert_event_labels() {
         run_test(|client_conn| async move {
             let data = vec![crate::types::EventMessage {
-                time: jiff::Timestamp::now(),
+                time: jiff::Timestamp::now()
+                    .as_nanosecond()
+                    .try_into()
+                    .unwrap_or_default(),
                 kind: crate::types::EventKind::ExtraThreat,
                 fields: vec![0x01, 0x02],
             }];

--- a/src/server.rs
+++ b/src/server.rs
@@ -544,7 +544,10 @@ mod tests {
         let mut handler = TestEventHandler::new();
 
         let event = EventMessage {
-            time: jiff::Timestamp::now(),
+            time: jiff::Timestamp::now()
+                .as_nanosecond()
+                .try_into()
+                .unwrap_or_default(),
             kind: EventKind::DnsCovertChannel,
             fields: vec![1, 2, 3, 4],
         };
@@ -586,7 +589,10 @@ mod tests {
 
         let mut handler = FailingHandler;
         let event = EventMessage {
-            time: jiff::Timestamp::now(),
+            time: jiff::Timestamp::now()
+                .as_nanosecond()
+                .try_into()
+                .unwrap_or_default(),
             kind: EventKind::HttpThreat,
             fields: vec![],
         };
@@ -729,7 +735,10 @@ mod tests {
 
             // Send test event
             let event = EventMessage {
-                time: jiff::Timestamp::now(),
+                time: jiff::Timestamp::now()
+                    .as_nanosecond()
+                    .try_into()
+                    .unwrap_or_default(),
                 kind: crate::types::EventKind::DnsCovertChannel,
                 fields: vec![1, 2, 3, 4],
             };
@@ -804,7 +813,10 @@ mod tests {
 
             // Send test event
             let event = EventMessage {
-                time: jiff::Timestamp::now(),
+                time: jiff::Timestamp::now()
+                    .as_nanosecond()
+                    .try_into()
+                    .unwrap_or_default(),
                 kind: crate::types::EventKind::HttpThreat,
                 fields: vec![5, 6, 7],
             };
@@ -888,7 +900,10 @@ mod tests {
 
                 // Send test event
                 let event = EventMessage {
-                    time: jiff::Timestamp::now(),
+                    time: jiff::Timestamp::now()
+                        .as_nanosecond()
+                        .try_into()
+                        .unwrap_or_default(),
                     kind: crate::types::EventKind::DnsCovertChannel,
                     fields: vec![u8::try_from(i).unwrap()],
                 };
@@ -998,7 +1013,10 @@ mod tests {
 
                 // Send test event
                 let event = EventMessage {
-                    time: jiff::Timestamp::now(),
+                    time: jiff::Timestamp::now()
+                        .as_nanosecond()
+                        .try_into()
+                        .unwrap_or_default(),
                     kind: crate::types::EventKind::DnsCovertChannel,
                     fields: vec![u8::try_from(i).unwrap()],
                 };

--- a/src/types.rs
+++ b/src/types.rs
@@ -282,8 +282,7 @@ pub enum EventKind {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EventMessage {
-    #[serde(with = "jiff::fmt::serde::timestamp::nanosecond::required")]
-    pub time: jiff::Timestamp,
+    pub time: i64,
     pub kind: EventKind,
     #[serde(with = "serde_bytes")]
     pub fields: Vec<u8>,
@@ -367,7 +366,10 @@ mod tests {
     fn event_message_with_blocklist_radius_serialization() {
         // Test EventMessage with BlocklistRadius variant
         let event = EventMessage {
-            time: jiff::Timestamp::now(),
+            time: jiff::Timestamp::now()
+                .as_nanosecond()
+                .try_into()
+                .unwrap_or_default(),
             kind: EventKind::BlocklistRadius,
             fields: vec![1, 2, 3, 4, 5],
         };


### PR DESCRIPTION
Close #124 

- Modify `time` field type to `i64` in EventMessage struct.